### PR TITLE
refactor: add cors directly in package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -882,11 +882,25 @@
         "tiny-lru": "^7.0.0"
       }
     },
+    "fastify-cors": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-6.0.2.tgz",
+      "integrity": "sha512-sE0AOyzmj5hLLRRVgenjA6G2iOGX35/1S3QGYB9rr9TXelMZB3lFrXy4CzwYVOMiujJeMiLgO4J7eRm8sQSv8Q==",
+      "requires": {
+        "fastify-plugin": "^3.0.0",
+        "vary": "^1.1.2"
+      }
+    },
     "fastify-error": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.3.1.tgz",
       "integrity": "sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ==",
       "dev": true
+    },
+    "fastify-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.0.tgz",
+      "integrity": "sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w=="
     },
     "fastify-warning": {
       "version": "0.2.0",
@@ -2042,6 +2056,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "url": "https://github.com/graasp/graasp-public-items/issues"
   },
   "homepage": "https://github.com/graasp/graasp-public-items#readme",
-  "dependencies": {},
+  "dependencies": {
+    "fastify-cors": "^6.0.2"
+  },
   "devDependencies": {
     "@types/eslint": "^7.2.5",
     "@types/graasp": "git://github.com/graasp/graasp-types.git#master",

--- a/src/service-api.ts
+++ b/src/service-api.ts
@@ -1,39 +1,52 @@
 // global
-import { FastifyPluginAsync } from 'fastify';
-import { Actor, IdParam } from 'graasp';
+import { FastifyPluginAsync } from "fastify";
+import { Actor, IdParam } from "graasp";
+import fastifyCors from "fastify-cors";
 // local
-import { PublicItemService } from './db-service';
-import common, {  getOne, getChildren } from './schemas';
-import { GetPublicItemTask } from './tasks/get-public-item';
-import { GetPublicItemChildrenTask } from './tasks/get-public-item-children';
+import { PublicItemService } from "./db-service";
+import common, { getOne, getChildren } from "./schemas";
+import { GetPublicItemTask } from "./tasks/get-public-item";
+import { GetPublicItemChildrenTask } from "./tasks/get-public-item-children";
 
 export interface GraaspItemLoginOptions {
   /** id of the tag to look for in the item to check if an item is public */
-  tagId: string,
-  graaspActor: Actor,
+  tagId: string;
+  graaspActor: Actor;
 }
 
 const plugin: FastifyPluginAsync<GraaspItemLoginOptions> = async (fastify, options) => {
   const { tagId, graaspActor } = options;
-  const { items: { dbService: iS }, taskRunner: runner } = fastify;
+  const {
+    items: { dbService: iS },
+    taskRunner: runner,
+  } = fastify;
 
   const pIS = new PublicItemService(tagId);
+
+  // add CORS support
+  if (fastify.corsPluginOptions) {
+    fastify.register(fastifyCors, fastify.corsPluginOptions);
+  }
 
   fastify.addSchema(common);
 
   fastify.get<{ Params: IdParam }>(
-    '/items/:id', { schema: getOne },
+    "/items/:id",
+    { schema: getOne },
     async ({ params: { id: itemId }, log }) => {
       const task = new GetPublicItemTask(graaspActor, itemId, pIS, iS);
       return runner.runSingle(task, log);
-    });
+    }
+  );
 
   fastify.get<{ Params: IdParam; Querystring: { ordered?: boolean } }>(
-    '/items/:id/children', { schema: getChildren },
+    "/items/:id/children",
+    { schema: getChildren },
     async ({ params: { id: itemId }, query: { ordered }, log }) => {
       const task = new GetPublicItemChildrenTask(graaspActor, itemId, pIS, iS, ordered);
       return runner.runSingle(task, log);
-    });
+    }
+  );
 };
 
 export default plugin;


### PR DESCRIPTION
Since adding cors from the core doesn't work (for some reason, is it related to `prefix` and `plugins`?), I added them directly in the plugin. This might also make sense as we might want "all" origins to access public items (and not just our interfaces).

close #1 